### PR TITLE
Fixed bug with checkbox rendering, added #ada_rare and #byroncenter_rare

### DIFF
--- a/config.json
+++ b/config.json
@@ -236,7 +236,8 @@
             "strokeWeight": 8,
             "minZoom": 10
           },
-          "hexes": [{"ring": 5, "offset": 16}, {"ring": 5, "offset": 17}, {"ring": 6, "offset": 20}]
+          "hexes": [{"ring": 5, "offset": 16}, {"ring": 5, "offset": 17}, {"ring": 6, "offset": 20},
+            {"ring": 5, "offset": 19}]
         },
         {
           "name": "#byroncenter_rare",
@@ -253,9 +254,28 @@
             "strokeOpacity": 0.2,
             "fillOpacity": 0
           },
-          "hexes": [{"ring": 5, "offset": 16}, {"ring": 5, "offset": 17}, {"ring": 6, "offset": 20}]
+          "hexes": [{"ring": 5, "offset": 16}, {"ring": 5, "offset": 17}, {"ring": 6, "offset": 20},
+            {"ring": 5, "offset": 19}]
         },
-		{
+        {
+          "name": "#byroncenter_rare",
+          "checkboxKey": "bc-rare",
+          "textStyle": {
+            "fontSize": 16,
+            "strokeWeight": 6,
+            "minZoom": 10
+          },
+          "style": {
+            "fillColor": "#FFFFFF",
+            "strokeColor": "#000000",
+            "strokeWeight": 3,
+            "strokeOpacity": 0.2,
+            "fillOpacity": 0
+          },
+          "hexes": [{"ring": 5, "offset": 16}, {"ring": 5, "offset": 17}, {"ring": 6, "offset": 20},
+            {"ring": 5, "offset": 19}]
+        },
+	      {
           "name": "Walker",
           "style": {
             "fillColor": "#FDFE14",

--- a/config.json
+++ b/config.json
@@ -6,7 +6,9 @@
   "zoom": 11,
   "checkboxes":{
     "dtowngr-rare": "#rare_notifications",
-    "dtowngr-omg": "#omgrarepokemon"
+    "dtowngr-omg": "#omgrarepokemon",
+    "ada-rare": "#ada_rare",
+    "bc-rare": "#byroncenter_rare"
   },
   "maps": [
     {
@@ -204,6 +206,24 @@
           "hexes": [{"ring": 2, "offset": 3}, {"ring": 3, "offset": 5}, {"ring": 4, "offset": 7}]
         },
         {
+          "name": "#ada_rare",
+          "checkboxKey": "ada-rare",
+          "textStyle": {
+            "fontSize": 16,
+            "strokeWeight": 6,
+            "minZoom": 10
+          },
+          "style": {
+            "fillColor": "#FFFFFF",
+            "strokeColor": "#000000",
+            "strokeWeight": 3,
+            "strokeOpacity": 0.2,
+            "fillOpacity": 0
+          },
+          "hexes": [{"ring": 3, "offset": 4}, {"ring": 4, "offset": 5}, {"ring": 4, "offset": 6},
+            {"ring": 2, "offset": 3}, {"ring": 3, "offset": 5}, {"ring": 4, "offset": 7}]
+        },
+        {
           "name": "Byron Center",
           "style": {
             "fillColor": "#FDFE14",
@@ -215,6 +235,23 @@
             "fontSize": 16,
             "strokeWeight": 8,
             "minZoom": 10
+          },
+          "hexes": [{"ring": 5, "offset": 16}, {"ring": 5, "offset": 17}, {"ring": 6, "offset": 20}]
+        },
+        {
+          "name": "#byroncenter_rare",
+          "checkboxKey": "bc-rare",
+          "textStyle": {
+            "fontSize": 16,
+            "strokeWeight": 6,
+            "minZoom": 10
+          },
+          "style": {
+            "fillColor": "#FFFFFF",
+            "strokeColor": "#000000",
+            "strokeWeight": 3,
+            "strokeOpacity": 0.2,
+            "fillOpacity": 0
           },
           "hexes": [{"ring": 5, "offset": 16}, {"ring": 5, "offset": 17}, {"ring": 6, "offset": 20}]
         },

--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
             var lbl = $('<label for="'+ckbx.attr('id')+'">' + config.checkboxes[regionConf.checkboxKey] + '</label>');
             $('#checkboxList').append(ckbx);
             $('#checkboxList').append(lbl);
+            $('#checkboxList').append('<br>');
             ckbx.on('click', ckbx, handleClick);
           }
         }


### PR DESCRIPTION
There was a bug where sufficiently short checkbox names would allow the next line's checkbox to be displayed on the current line. IE, for "#ada_rare", the "#byroncenter_rare" checkbox would be shown at the end of the "#ada_rare" line. Adding a `<br>` forces a line break, preventing the issue.

I also added the two channels mentioned.